### PR TITLE
Battery data spikes

### DIFF
--- a/custom_components/kostal_piko/const.py
+++ b/custom_components/kostal_piko/const.py
@@ -59,39 +59,6 @@ class KostalPikoEntityDescription(SensorEntityDescription):
 
 # Defines all possible sensors
 SENSOR_TYPES: tuple[KostalPikoEntityDescription, ...] = (
-    # Analog Input sensors
-    KostalPikoEntityDescription(
-        device_class=SensorDeviceClass.VOLTAGE,
-        key=str(kostal.ActualAnalogInputs.ANALOG1),
-        name="Analog Input 1",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        formatter=round_one,
-    ),
-    KostalPikoEntityDescription(
-        device_class=SensorDeviceClass.VOLTAGE,
-        key=str(kostal.ActualAnalogInputs.ANALOG2),
-        name="Analog Input 2",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        formatter=round_one,
-    ),
-    KostalPikoEntityDescription(
-        device_class=SensorDeviceClass.VOLTAGE,
-        key=str(kostal.ActualAnalogInputs.ANALOG3),
-        name="Analog Input 3",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        formatter=round_one,
-    ),
-    KostalPikoEntityDescription(
-        device_class=SensorDeviceClass.VOLTAGE,
-        key=str(kostal.ActualAnalogInputs.ANALOG4),
-        name="Analog Input 4",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        formatter=round_one,
-    ),
     # Battery sensors
     KostalPikoEntityDescription(
         device_class=SensorDeviceClass.VOLTAGE,
@@ -137,6 +104,39 @@ SENSOR_TYPES: tuple[KostalPikoEntityDescription, ...] = (
         key=str(kostal.ActualBattery.TEMPERATURE),
         name="Battery Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        formatter=round_one,
+    ),
+    # Analog Input sensors
+    KostalPikoEntityDescription(
+        device_class=SensorDeviceClass.VOLTAGE,
+        key=str(kostal.ActualAnalogInputs.ANALOG1),
+        name="Analog Input 1",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        formatter=round_one,
+    ),
+    KostalPikoEntityDescription(
+        device_class=SensorDeviceClass.VOLTAGE,
+        key=str(kostal.ActualAnalogInputs.ANALOG2),
+        name="Analog Input 2",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        formatter=round_one,
+    ),
+    KostalPikoEntityDescription(
+        device_class=SensorDeviceClass.VOLTAGE,
+        key=str(kostal.ActualAnalogInputs.ANALOG3),
+        name="Analog Input 3",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        formatter=round_one,
+    ),
+    KostalPikoEntityDescription(
+        device_class=SensorDeviceClass.VOLTAGE,
+        key=str(kostal.ActualAnalogInputs.ANALOG4),
+        name="Analog Input 4",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         formatter=round_one,
     ),

--- a/custom_components/kostal_piko/manifest.json
+++ b/custom_components/kostal_piko/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "issue_tracker": "https://github.com/scheidtdav/homeassistant-kostal-piko/issues",
   "iot_class": "local_polling",
-  "requirements": ["pykostal==0.0.2"],
+  "requirements": ["pykostal==0.0.2","backoff==2.2.1"],
   "version": "24.12.0"
 }


### PR DESCRIPTION
Details are described already within issue #19 . Thus this is only a brief wrap up.
## Problem
When reading battery related data from the kostal interaface, I have quite often (5 to 19) invalid readings of e.g. SOC temperature, etc. With all values beeing zero. (Yet I don't know whether this is just my inverter - or whether this is a common issue)

## Solution
- Detect those invalid readings and force a retry - e.g. 3s later all values are fine again.
- use a decorator to handle the retry upon failure
- reorder the dxs antries to ensure that all battery related data is read within one query update the dependencies

Closes #19
Fixes #19
Resolves #19